### PR TITLE
Issue with invisible project when currentproject changes outside of the research window

### DIFF
--- a/Source/MainTabWindow_ResearchTree.cs
+++ b/Source/MainTabWindow_ResearchTree.cs
@@ -169,7 +169,7 @@ namespace ResearchPal
             _dragging             = false;
             closeOnClickedOutside = false;
 
-            if (Queue.CountS() == 0 && Find.ResearchManager.currentProj != null)
+            if (Find.ResearchManager.currentProj != null)
                 Queue.AppendS(new ResearchNode(Find.ResearchManager.currentProj));
         }
 

--- a/Source/MainTabWindow_ResearchTree.cs
+++ b/Source/MainTabWindow_ResearchTree.cs
@@ -168,6 +168,9 @@ namespace ResearchPal
 
             _dragging             = false;
             closeOnClickedOutside = false;
+
+            if (Queue.CountS() == 0 && Find.ResearchManager.currentProj != null)
+                Queue.AppendS(new ResearchNode(Find.ResearchManager.currentProj));
         }
 
         private void SetRects()

--- a/Source/MainTabWindow_ResearchTree.cs
+++ b/Source/MainTabWindow_ResearchTree.cs
@@ -168,10 +168,6 @@ namespace ResearchPal
 
             _dragging             = false;
             closeOnClickedOutside = false;
-
-            //update current queue in case currentProj changed
-            if (Find.ResearchManager.currentProj != null) 
-                Queue.AppendS(Find.ResearchManager.currentProj.ResearchNode());
         }
 
         private void SetRects()

--- a/Source/MainTabWindow_ResearchTree.cs
+++ b/Source/MainTabWindow_ResearchTree.cs
@@ -169,8 +169,9 @@ namespace ResearchPal
             _dragging             = false;
             closeOnClickedOutside = false;
 
-            if (Find.ResearchManager.currentProj != null)
-                Queue.AppendS(new ResearchNode(Find.ResearchManager.currentProj));
+            //update current queue in case currentProj changed
+            if (Find.ResearchManager.currentProj != null) 
+                Queue.AppendS(Find.ResearchManager.currentProj.ResearchNode());
         }
 
         private void SetRects()

--- a/Source/Queue/Queue.cs
+++ b/Source/Queue/Queue.cs
@@ -94,7 +94,7 @@ namespace ResearchPal
             }
         }
 
-        public bool CantResearch(ResearchNode node) {
+        static public bool CantResearch(ResearchNode node) {
             return !node.GetAvailable();
         }
 
@@ -171,6 +171,10 @@ namespace ResearchPal
             }
             finished.ForEach(n => _queue.Remove(n));
             unavailable.ForEach(n => Remove(n));
+            //
+            if (CountS() == 0 && Find.ResearchManager.currentProj != null)
+                ReplaceS(Find.ResearchManager.currentProj.ResearchNode());
+            //
             UpdateCurrentResearch();
         }
 


### PR DESCRIPTION
Currently ResearchPal window has issues if current project was changed outside of the window. Not a big deal in vanilla, but it's a trouble if there are any mods that could do that. This tiny fix should help.